### PR TITLE
fix prompt format bug -- missing <video> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ from eval import load_decord
 from model import create_videoccam
 
 video_path = 'assets/example.mp4'
-question = 'Can you please describe what happens in the video in detail?'
+question = '<video>\nCan you please describe what happens in the video in detail?'
 
 sample_config = dict(
     sample_type='uniform',


### PR DESCRIPTION
The given script is missing "\<video>" tag that causes the error in generation.